### PR TITLE
Add Linux AArch64 wheel build support

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -14,6 +14,21 @@ env:
 
 jobs:
 
+  create_wheels_manylinux_aarch64:
+    runs-on: ubuntu-latest
+    name: Create wheels for manylinux2014 Linux AArch64
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Build and audit wheels
+        run: |
+            docker run --rm -v ${{ github.workspace }}:/ws:rw \
+            --workdir=/ws/bindings/python quay.io/pypa/manylinux2014_aarch64 \
+            bash -exc 'yum install -y openssl-devel && sh build-wheels.sh'
+
   create_wheels_manylinux:
     runs-on: ubuntu-latest
     name: Create wheels for manylinux2010
@@ -23,7 +38,7 @@ jobs:
 
       - name: Build and audit wheels
         working-directory: ./bindings/python
-        run: sh build-wheels.sh
+        run: yum install -y openssl-devel && sh build-wheels.sh
 
   create_wheels_windows_32bit:
     name: Create wheels for windows 32-bit


### PR DESCRIPTION
Owner: Madhukar
Fix: Linux AArch64 wheel build support
Build Logs: https://github.com/odidev/tokenizers/runs/4151954793?check_suite_focus=true
Reviewer: Pruthvi and Disha